### PR TITLE
fix spacing on the home page and improve row component

### DIFF
--- a/Revill/Revill/View/Feed/ListOfGames.swift
+++ b/Revill/Revill/View/Feed/ListOfGames.swift
@@ -15,7 +15,7 @@ struct ListOfGames: View {
             RowGames()
             RowGames()
             RowGames()
-            }.background(Color.purple).offset(x: 0, y: -30)
+            }.background(Color.purple).offset(x: 0, y: -10)
     }
 }
 

--- a/Revill/Revill/View/Feed/RowGames.swift
+++ b/Revill/Revill/View/Feed/RowGames.swift
@@ -10,17 +10,31 @@ import SwiftUI
 
 struct RowGames: View {
     var body: some View {
-         VStack {
-           HStack {
-            Image("highPlaceHolder").resizable().frame(width: 77 ,height: 77).cornerRadius(8).padding(.leading, 10).padding(.top, 10).padding(.bottom, 10)
-           
-            VStack(alignment: .leading) {
-                Text("The last of Us").foregroundColor(Color.black).font(.headline)
-                Text("Survivor").foregroundColor(Color.gray).font(.subheadline)
+        VStack {
+            HStack(alignment: .top) {
+                Image("highPlaceHolder")
+                    .resizable()
+                    .frame(width: 77 ,height: 77)
+                    .cornerRadius(8)
+                    .padding(10)
+                
+                VStack(alignment: .leading) {
+                    Text("The last of Us")
+                        .foregroundColor(Color.black)
+                        .font(.headline)
+                    Text("Survivor")
+                        .foregroundColor(Color.gray)
+                        .font(.subheadline)
+                }
+                .padding(10)
+                
                 Spacer()
-            }.padding()
-            Spacer()
-           }.background(Color.white).cornerRadius(16)
-            }.listRowBackground(Color.purple).listRowInsets(EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)).shadow(color: Color.black, radius: 2, x: 0, y: 2)
+            }
+            .background(Color.white)
+            .cornerRadius(16)
+        }
+        .listRowBackground(Color.purple)
+        .listRowInsets(EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10))
+        .shadow(color: Color.black, radius: 2, x: 0, y: 2)
     }
 }


### PR DESCRIPTION
### spacing before (going on top of element): 

<img width="334" alt="Screenshot 2019-10-07 at 16 02 56" src="https://user-images.githubusercontent.com/14620121/66321833-7a815680-e921-11e9-9007-03247353edf0.png">

### spacing after: 
<img width="336" alt="Screenshot 2019-10-07 at 16 02 15" src="https://user-images.githubusercontent.com/14620121/66321913-971d8e80-e921-11e9-9ea4-30722dcc6a74.png">

also improved a bit the `RowGames` component:
- break props into new lines so visualisation is better 
- add `(alignment: .top)` to `HStack` so we don't need `Spacer()` to force elements to go up 